### PR TITLE
Compatibility fixes for 3.5

### DIFF
--- a/rocket/src/test/scala/amba/axi4/DMATests.scala
+++ b/rocket/src/test/scala/amba/axi4/DMATests.scala
@@ -8,7 +8,8 @@ import freechips.rocketchip.diplomacy.{AddressSet, LazyModule, LazyModuleImp, La
 import freechips.rocketchip.subsystem.{PeripheryBus, PeripheryBusParams}
 import freechips.rocketchip.system.BaseConfig
 import freechips.rocketchip.tilelink.{TLBundleParameters, TLFragmenter, TLIdentityNode, TLToAXI4}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class StreamingAXI4DMAWithMemoryTester(dut: StreamingAXI4DMAWithMemory with AXI4StandaloneBlock, silentFail: Boolean = false)
   extends PeekPokeTester(dut.module)
@@ -181,7 +182,7 @@ class DMASimplifierTester(dut: DMASimplifier) extends PeekPokeTester(dut) {
   }
 }
 
-class DmaSpec extends FlatSpec with Matchers {
+class DmaSpec extends AnyFlatSpec with Matchers {
   implicit val p: Parameters = (new BaseConfig).toInstance
 
   behavior of "DMASimplifier"

--- a/rocket/src/test/scala/amba/axi4stream/AXI4StreamSpec.scala
+++ b/rocket/src/test/scala/amba/axi4stream/AXI4StreamSpec.scala
@@ -9,7 +9,8 @@ import freechips.rocketchip.amba.axi4stream
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class TestModule(val inP: AXI4StreamBundleParameters,
                  outP: AXI4StreamSlaveParameters,
@@ -166,7 +167,7 @@ object StreamMuxTester {
   }
 }
 
-class AXI4StreamSpec extends FlatSpec with Matchers {
+class AXI4StreamSpec extends AnyFlatSpec with Matchers {
   behavior of "AXI4 Stream Nodes"
   it should "work with fuzzer and identity" in {
     val inP  = AXI4StreamBundleParameters(n = 2)

--- a/rocket/src/test/scala/craft/ShiftRegisterMemSpec.scala
+++ b/rocket/src/test/scala/craft/ShiftRegisterMemSpec.scala
@@ -4,7 +4,8 @@ package craft
 
 import chisel3._
 import dsptools.DspTester
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class SRMemModule( dut: (UInt, Bool) => UInt ) extends Module {
   val io = IO(new Bundle {
@@ -30,7 +31,7 @@ class SRMemTester( dut: SRMemModule, input: Seq[(Int, Boolean)], expected_output
 }
 
 //noinspection RedundantDefaultArgument,RedundantDefaultArgument,RedundantDefaultArgument,RedundantDefaultArgument
-class ShiftRegisterMemSpec extends FlatSpec with Matchers {
+class ShiftRegisterMemSpec extends AnyFlatSpec with Matchers {
   behavior of "ShiftRegisterMem"
 
   val testVector: Seq[(Int, Boolean)] = Seq(

--- a/rocket/src/test/scala/dspblocks/DspBlockSpec.scala
+++ b/rocket/src/test/scala/dspblocks/DspBlockSpec.scala
@@ -5,9 +5,10 @@ package dspblocks
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.system.BaseConfig
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DspBlockSpec extends FlatSpec with Matchers {
+class DspBlockSpec extends AnyFlatSpec with Matchers {
   implicit val p: Parameters = (new BaseConfig).toInstance
 
   behavior of "Passthrough"

--- a/rocket/src/test/scala/dspblocks/DspRegisterSpec.scala
+++ b/rocket/src/test/scala/dspblocks/DspRegisterSpec.scala
@@ -7,8 +7,8 @@ import freechips.rocketchip.amba.axi4._
 import freechips.rocketchip.amba.axi4stream._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import org.scalatest.{FlatSpec, Matchers}
-import DoubleToBigIntRand._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class DspRegisterTestModule(
                   val inP: AXI4StreamBundleParameters,
@@ -74,7 +74,7 @@ class DspRegisterTestModuleTester(c: DspRegisterTestModule,
   println(s"${axiReadWord(0)} is the veclen")
 }
 
-class DspRegisterSpec extends FlatSpec with Matchers {
+class DspRegisterSpec extends AnyFlatSpec with Matchers {
   behavior of "AXI4DspRegister"
 
   it should "be able to read and write" ignore {

--- a/rocket/src/test/scala/jtag2mm/Jtag2AXI4MultiplexerTester.scala
+++ b/rocket/src/test/scala/jtag2mm/Jtag2AXI4MultiplexerTester.scala
@@ -2,24 +2,11 @@
 
 package freechips.rocketchip.jtag2mm
 
-import chisel3._
-import chisel3.util._
-import chisel3.experimental._
-import chisel3.experimental.{withClockAndReset}
-
 import dsptools._
-import dsptools.numbers._
-
-import dspblocks._
-import freechips.rocketchip.amba.axi4._
-import freechips.rocketchip.amba.axi4stream._
 import freechips.rocketchip.config._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.regmapper._
-
-import chisel3.iotesters.Driver
-import chisel3.iotesters.PeekPokeTester
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 //class Jtag2AXI4MultiplexerTester(dut: Jtag2AXI4Multiplexer) extends PeekPokeTester(dut.module) {
 class Jtag2AXI4MultiplexerTester(dut: Jtag2AXI4Multiplexer) extends DspTester(dut.module) {
@@ -235,7 +222,7 @@ class Jtag2AXI4MultiplexerTester(dut: Jtag2AXI4Multiplexer) extends DspTester(du
   step(300)
 }
 
-class Jtag2AXI4MultiplexerSpec extends FlatSpec with Matchers {
+class Jtag2AXI4MultiplexerSpec extends AnyFlatSpec with Matchers {
   implicit val p: Parameters = Parameters.empty
 
   val irLength = 4

--- a/rocket/src/test/scala/jtag2mm/Jtag2TLMultiplexerTester.scala
+++ b/rocket/src/test/scala/jtag2mm/Jtag2TLMultiplexerTester.scala
@@ -5,7 +5,6 @@ package freechips.rocketchip.jtag2mm
 import chisel3._
 import chisel3.util._
 import chisel3.experimental._
-import chisel3.experimental.{withClockAndReset}
 
 import dsptools._
 import dsptools.numbers._
@@ -20,7 +19,8 @@ import freechips.rocketchip.tilelink._
 
 import chisel3.iotesters.Driver
 import chisel3.iotesters.PeekPokeTester
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 //class Jtag2TLMultiplexerTester(dut: Jtag2TLMultiplexer) extends PeekPokeTester(dut.module) {
 class Jtag2TLMultiplexerTester(dut: Jtag2TLMultiplexer) extends DspTester(dut.module) {
@@ -236,7 +236,7 @@ class Jtag2TLMultiplexerTester(dut: Jtag2TLMultiplexer) extends DspTester(dut.mo
   step(300)
 }
 
-class Jtag2TLMultiplexerSpec extends FlatSpec with Matchers {
+class Jtag2TLMultiplexerSpec extends AnyFlatSpec with Matchers {
   implicit val p: Parameters = Parameters.empty
 
   val irLength = 4

--- a/rocket/src/test/scala/jtag2mm/JtagFuzzerTester.scala
+++ b/rocket/src/test/scala/jtag2mm/JtagFuzzerTester.scala
@@ -8,7 +8,8 @@ import chisel3.util.random.LFSR
 import chisel3.experimental._
 import chisel3.iotesters.Driver
 import chisel3.iotesters.PeekPokeTester
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import dsptools.DspTester
 
 class JtagFuzzerTester(dut: JtagFuzzer) extends DspTester(dut) {
@@ -19,7 +20,7 @@ class JtagFuzzerTester(dut: JtagFuzzer) extends DspTester(dut) {
 }
 
 
-class JtagFuzzerSpec extends FlatSpec with Matchers {
+class JtagFuzzerSpec extends AnyFlatSpec with Matchers {
 
   def dut(irLength: Int, beatBytes: Int, numOfTransfers: Int): () => JtagFuzzer = () => {
     new JtagFuzzer(irLength, beatBytes, numOfTransfers)

--- a/rocket/src/test/scala/tester/MemMasterSpec.scala
+++ b/rocket/src/test/scala/tester/MemMasterSpec.scala
@@ -9,7 +9,8 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.interrupts._
 import freechips.rocketchip.regmapper._
 import freechips.rocketchip.tilelink._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 trait RegmapExample extends HasRegMap {
   val r0 = RegInit(0.U(64.W))
@@ -97,7 +98,7 @@ class APBRegmapExample extends APBRegisterRouter(0, beatBytes = 8, interrupts = 
   }
 }
 
-class MemMasterSpec extends FlatSpec with Matchers {
+class MemMasterSpec extends AnyFlatSpec with Matchers {
   abstract class RegmapExampleTester[M <: MultiIOModule](c: M) extends PeekPokeTester(c) with MemMasterModel {
     memReadWord(0x00) should be (0)
     memReadWord(0x08) should be (1)


### PR DESCRIPTION
Compatibility fixes for 3.5
- Driver now uses iotesters compatibility stuff
- Tests change to used last scala tests
  - add `Any` prefix to scalatest class names
  - Matchers import has changed
  - withClockAndReset moved out of experimental package